### PR TITLE
cywiriadau achos diwedd Python2 / fixes because of Python EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,17 @@ RUN dpkg --add-architecture i386
 
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk vim git curl wget zip locales maven  \
-	   python3 python3-pip software-properties-common \
+	   software-properties-common build-essential cmake libssl-dev libboost-all-dev zlib1g-dev libffi-dev \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Upgrade to Python3.7
+RUN wget -c https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz && \
+    tar xf Python-3.7.4.tar.xz && \
+    cd Python-3.7.4 && ./configure -q && make && make install && \
+    apt update && \
+    apt install -y python3 python3-dev python3-setuptools python3-pip
+
+RUN python3 -m pip install --upgrade pip 
 
 # Set the locale
 RUN locale-gen cy_GB.UTF-8

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Ac yna:
 
 Bydd hyn yn cychwyn gweinydd testun-i-leferydd gyda'r llais Cymraeg (wispr-cy-male-unitselection-general) yn barod i'w ddefnyddio. 
 
-Agorwch borwr ac ewch i `http://localhost:52010` i'w glywed yn ynganu eich testunau.
+Agorwch borwr ac ewch i `http://localhost:52010` i'w glywed yn ynganu eich testunau neu defnyddiwch y gorchymyn CURL:
+
+ $ curl -o sound.wav "http://localhost:52010/process?INPUT_TEXT=Helo+pawb&INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE&VOICE=wispr&LOCALE=cy"
 
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,10 +11,7 @@ ADD cherrypy/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 WORKDIR /opt/marytts-server
 
 RUN pip3 install --upgrade pip
-RUN pip3 install -r requirements.txt 
-
-#RUN mkdir -p /var/log/gunicorn \
-# && touch /var/log/gunicorn/marytts-api.error.log
+RUN python3 -m pip install -r requirements.txt 
 
 EXPOSE 8008
 


### PR DESCRIPTION
Mae'r newidiadau pellach yma yn adeiladu bopeth ac yn galluogi'r `server` i weithio eto gyda'r ddau lais 'default'

*these further changes successfully builds everything that's needed for the 'server' to generate speech from the two default voices*

The `make`in the `server` directory was giving me the error message below...

```
Step 7/10 : RUN pip3 install --upgrade pip
 ---> Running in c454cba07e9c
Collecting pip
  Downloading https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl (1.7MB)
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
Successfully installed pip-21.3.1
Removing intermediate container c454cba07e9c
 ---> 75fd3d39e088
Step 8/10 : RUN pip3 install -r requirements.txt
 ---> Running in 5a8fd320219e
Traceback (most recent call last):
  File "/usr/local/bin/pip3", line 7, in <module>
    from pip._internal.cli.main import main
  File "/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py", line 57
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
The command '/bin/sh -c pip3 install -r requirements.txt' returned a non-zero code: 1
Makefile:7: recipe for target 'build' failed
make: *** [build] Error 1
```
